### PR TITLE
Postfix bounces address aren't RFC compliant

### DIFF
--- a/eazye.go
+++ b/eazye.go
@@ -112,7 +112,7 @@ func GenerateSince(info MailboxInfo, since time.Time, markAsRead, delete bool) (
 type Email struct {
 	Message *mail.Message
 
-	From         *mail.Address   `json:"from"`
+	From         string          `json:"from"`
 	To           []*mail.Address `json:"to"`
 	InternalDate time.Time       `json:"internal_date"`
 	Precedence   string          `json:"precedence"`
@@ -503,9 +503,18 @@ func newEmail(msgFields imap.FieldMap) (Email, error) {
 		return email, fmt.Errorf("unable to read header: %s", err)
 	}
 
-	from, err := mail.ParseAddress(msg.Header.Get("From"))
-	if err != nil {
-		return email, fmt.Errorf("unable to parse from address: %s", err)
+	rawFrom := msg.Header.Get("From")
+	rawFromSl := strings.Fields(rawFrom)
+	from := ""
+	for _, rF := range rawFromSl {
+		f, err := mail.ParseAddress(rF)
+		if err != nil {
+			continue
+		}
+		from = f.Address
+	}
+	if len(from) == 0 {
+		from = rawFrom
 	}
 
 	to, err := mail.ParseAddressList(msg.Header.Get("To"))


### PR DESCRIPTION
so we can explode the From and parse each field to find real from address

Example :
[...]
From: MAILER-DAEMON@deXXX.ispfr.net (Mail Delivery System)
[...]