### PR TITLE
If Field To doesn't parse as Address Slice, leave it empty

### DIFF
--- a/eazye.go
+++ b/eazye.go
@@ -510,7 +510,7 @@ func newEmail(msgFields imap.FieldMap) (Email, error) {
 
 	to, err := mail.ParseAddressList(msg.Header.Get("To"))
 	if err != nil {
-		return email, fmt.Errorf("unable to parse to address: %s", err)
+		to = []*mail.Address{}
 	}
 
 	email = Email{


### PR DESCRIPTION
 as RFC say "may contains"
https://tools.ietf.org/html/rfc5322#section-3.6.3