### PR TITLE
Fix decoding base64

### DIFF
--- a/eazye.go
+++ b/eazye.go
@@ -529,7 +529,8 @@ func parsePart(mediaType, charsetStr, encoding string, part []byte) (html, text 
 			return
 		}
 	case "base64":
-		_, err = base64.StdEncoding.Decode(part, body)
+		decoder := base64.NewDecoder(base64.StdEncoding, bytes.NewReader(part))
+		body, err = ioutil.ReadAll(decoder)
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
I did it like "qprintable" above. Previous solution does not work with gmail emails sending from my bank. Body was always empty. 