### PR TITLE
Added UID to Email structure

### DIFF
--- a/eazye.go
+++ b/eazye.go
@@ -118,7 +118,6 @@ func MarkAsUnread(info MailboxInfo, uids []uint32) error {
 		client.Logout(30 * time.Second)
 	}()
 	for _, u := range uids {
-		fmt.Println("Setting unseen on", u)
 		err := alterEmail(client, u, "\\SEEN", false)
 		if err != nil {
 			return err //return on first failure
@@ -140,7 +139,6 @@ func DeleteEmails(info MailboxInfo, uids []uint32) error {
 		client.Logout(30 * time.Second)
 	}()
 	for _, u := range uids {
-		fmt.Println("Deleting UID ", u)
 		err := deleteEmail(client, u)
 		if err != nil {
 			return err //return on first failure


### PR DESCRIPTION
I had the situation where I wanted to retrieve emails and either mark them as unread or delete them depending on some criteria. I couldn't find a way to do this so added email UID to the Email struct, and two functions to either mark emails as unseen or delete them based on a supplied slice of UIDs.

It's a little inefficient as it's required to re-authenticate to the IMAP server, which is why I chose to supply a slice of UIDs rather than one at a time. 

e.g usage:

```msgs, _ := eazye.GetUnread(mailSettings, true, false) // Get emails and mark as read
var myEmails []uint32
for _, m := range msgs {
    myEmails = append(myEmails, m.UID)
}
_ := eazye.MarkAsUnread(mailSettings, myEmails) //Actually let's mark them as unread
_ := eazye.DeleteEmails(mailSettings, []uint32{myEmails[0]}) //And delete the first email
```