### PR TITLE
Added IMAP Command Search Function

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ func GenerateSince(info MailboxInfo, since time.Time, markAsRead, delete bool) (
 ##### ... or all mail matching an IMAP search
 
 ```go
-// GetCommand will pull all emails that have an internal date after the given time.
+// GetCommand will pull all emails that match the provided IMAP Command.
+// Examples of IMAP Commands include TO/FROM/BCC, some examples are here http://www.marshallsoft.com/ImapSearch.htm
 func GetCommand(info MailboxInfo, IMAPCommand string, markAsRead, delete bool)
 ```
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ func GetSince(info MailboxInfo, since time.Time, markAsRead, delete bool)
 func GenerateSince(info MailboxInfo, since time.Time, markAsRead, delete bool) (chan Response, error)
 ```
 
-##### ... or all mail matching an IMAP search
+##### ... or all mail matching an IMAP Command search
 
 ```go
 // GetCommand will pull all emails that match the provided IMAP Command.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ func GetSince(info MailboxInfo, since time.Time, markAsRead, delete bool)
 func GenerateSince(info MailboxInfo, since time.Time, markAsRead, delete bool) (chan Response, error)
 ```
 
+##### ... or all mail matching an IMAP search
+
+```go
+// GetCommand will pull all emails that have an internal date after the given time.
+func GetCommand(info MailboxInfo, IMAPCommand string, markAsRead, delete bool)
+```
+
+
 ##### `eazye` will pull out the most common headers and bits but also provides the `mail.Message` in case you want to pull additional data.
 
 ```go
@@ -77,7 +85,7 @@ type Response struct {
 }
 ```
 
-This package has several dependencies: 
+This package has several dependencies:
 * github.com/mxk/go-imap/imap
 * github.com/paulrosania/charset
 * github.com/paulrosania/go-charset/data

--- a/eazye.go
+++ b/eazye.go
@@ -62,7 +62,8 @@ func GenerateCommand(info MailboxInfo, IMAPCommand string, markAsRead, delete bo
 	return generateMail(info, IMAPCommand, nil, markAsRead, delete)
 }
 
-// GetCommand will find all emails in the folder matching the IMAP command and return them as a list.
+// GetCommand will pull all emails that match the provided IMAP Command.
+// Examples of IMAP Commands include TO/FROM/BCC, some examples are here http://www.marshallsoft.com/ImapSearch.htm
 func GetCommand(info MailboxInfo, IMAPCommand string, markAsRead, delete bool) ([]Email, error) {
 	responses, err := GenerateCommand(info, IMAPCommand, markAsRead, delete)
 	return emailToList(responses, err)

--- a/eazye.go
+++ b/eazye.go
@@ -57,12 +57,26 @@ func GenerateAll(info MailboxInfo, markAsRead, delete bool) (chan Response, erro
 	return generateMail(info, "ALL", nil, markAsRead, delete)
 }
 
+// GenerateCommand will find all emails in the email folder matching the IMAP command and pass them along to the responses channel.
+func GenerateCommand(info MailboxInfo, IMAPCommand string, markAsRead, delete bool) (chan Response, error) {
+	return generateMail(info, IMAPCommand, nil, markAsRead, delete)
+}
+
+// GetCommand will find all emails in the folder matching the IMAP command and return them as a list.
+func GetCommand(info MailboxInfo, IMAPCommand string, markAsRead, delete bool) ([]Email, error) {
+	responses, err := GenerateCommand(info, IMAPCommand, markAsRead, delete)
+	return emailToList(responses, err)
+}
+
 // GetUnread will find all unread emails in the folder and return them as a list.
 func GetUnread(info MailboxInfo, markAsRead, delete bool) ([]Email, error) {
+	responses, err := GenerateUnread(info, markAsRead, delete)
+	return emailToList(responses, err)
+}
+
+func emailToList(responses chan Response, err error) ([]Email, error) {
 	// call chan, put 'em in a list, return
 	var emails []Email
-
-	responses, err := GenerateUnread(info, markAsRead, delete)
 	if err != nil {
 		return emails, err
 	}
@@ -73,7 +87,6 @@ func GetUnread(info MailboxInfo, markAsRead, delete bool) ([]Email, error) {
 		}
 		emails = append(emails, resp.Email)
 	}
-
 	return emails, nil
 }
 

--- a/eazye.go
+++ b/eazye.go
@@ -66,16 +66,16 @@ func GenerateCommand(info MailboxInfo, IMAPCommand string, markAsRead, delete bo
 // Examples of IMAP Commands include TO/FROM/BCC, some examples are here http://www.marshallsoft.com/ImapSearch.htm
 func GetCommand(info MailboxInfo, IMAPCommand string, markAsRead, delete bool) ([]Email, error) {
 	responses, err := GenerateCommand(info, IMAPCommand, markAsRead, delete)
-	return emailToList(responses, err)
+	return responseToList(responses, err)
 }
 
 // GetUnread will find all unread emails in the folder and return them as a list.
 func GetUnread(info MailboxInfo, markAsRead, delete bool) ([]Email, error) {
 	responses, err := GenerateUnread(info, markAsRead, delete)
-	return emailToList(responses, err)
+	return responseToList(responses, err)
 }
 
-func emailToList(responses chan Response, err error) ([]Email, error) {
+func responseToList(responses chan Response, err error) ([]Email, error) {
 	// call chan, put 'em in a list, return
 	var emails []Email
 	if err != nil {


### PR DESCRIPTION
Allows a user to run a search directly on IMAP by passing the command to a function. I needed a way to search by sender address, so this seemed like the nicest way to implement it.

Also abstracted the function to convert emails to list so it can be reused, and implemented it in both GetCommand and GetUnread.

