### PR TITLE
Added option to allow bad/invalid server certificates

### DIFF
--- a/eazye.go
+++ b/eazye.go
@@ -24,11 +24,12 @@ import (
 // MailboxInfo holds onto the credentials and other information
 // needed for connecting to an IMAP server.
 type MailboxInfo struct {
-	Host   string
-	TLS    bool
-	User   string
-	Pwd    string
-	Folder string
+	Host               string
+	TLS                bool
+	InsecureSkipVerify bool
+	User               string
+	Pwd                string
+	Folder             string
 	// Read only mode, false (original logic) if not initialized
 	ReadOnly bool
 }
@@ -293,7 +294,9 @@ func newIMAPClient(info MailboxInfo) (*imap.Client, error) {
 	var client *imap.Client
 	var err error
 	if info.TLS {
-		client, err = imap.DialTLS(info.Host, new(tls.Config))
+		config := new(tls.Config)
+		config.InsecureSkipVerify = info.InsecureSkipVerify
+		client, err = imap.DialTLS(info.Host, config)
 		if err != nil {
 			return client, err
 		}


### PR DESCRIPTION
Added a `MailboxInfo` boolean option `InsecureSkipVerify` to allow invalid certificates.

To test this, and if you don't have an IMAP server handy with an invalid certificate we can pivot through a socat listener to Google's IMAP server like so:

```
# Make certs and setup MiTM to GMail's IMAP server
openssl req -new -x509 -keyout test.key -out test.crt -nodes
cat test.key test.crt > test.pem 

socat -v tcp4-listen:6500,reuseaddr,fork ssl:imap.gmail.com:993,verify=0 &
socat -v openssl-listen:993,cert=test.pem,verify=0,reuseaddr,fork tcp4:localhost:6500
```

And then run this test code, with the new `InsecureSkipVerify: true` :
```
mailSettings := eazye.MailboxInfo{
		Host:               "localhost",
		TLS:                true,
		InsecureSkipVerify: true, // true will allow bad certs
		User:               "mygmailuser",
		Pwd:                "mygmailpass",
		Folder:             "INBOX"}

fmt.Printf("Checking for new emails on '%s'....\n", mailSettings.Host)

msgs, err := eazye.GetUnread(mailSettings, false, false)
if err != nil {
    panic(err)
}

if len(msgs) > 0 {
    log.Printf("Found %d new emails.\n", len(msgs))
} else {
    log.Println("No new emails")
}
```
